### PR TITLE
chore: AP-112233 add auto-assign PR workflow

### DIFF
--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -1,0 +1,15 @@
+name: Auto assign to author
+
+on:
+  pull_request:
+    types: [ opened ]
+    branches: [ master, main, develop ]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  auto-assign:
+    name: Auto-assign PR to author
+    uses: aplazo/.github/.github/workflows/auto-assign-author.yml@v.1.2.0


### PR DESCRIPTION
Adds the `auto-assign-pr.yml` GitHub Actions workflow so that every PR is automatically assigned to its author when opened.

This workflow calls the shared reusable workflow `aplazo/.github/.github/workflows/auto-assign-author.yml@v.1.2.0`.