### PR TITLE
chore: ID-295 add Backstage catalog metadata

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -16,6 +16,7 @@ spec:
   type: service
   lifecycle: production
   owner: group:default/flagship-squad
+  system: system:default/walmart-cashi-integration-system
   dependsOn:
   - resource:default/shared-nosql-database
   - resource:default/datadog

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -16,7 +16,7 @@ spec:
   type: service
   lifecycle: production
   owner: group:default/flagship-squad
-  system: system:default/walmart-cashi-integration-system
+  system: system:default/authn-authz-system
   dependsOn:
   - resource:default/shared-nosql-database
   - resource:default/datadog

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,21 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: oauth2
+  title: OAUTH2
+  description: The only web-scale, fully customizable OpenID Certified™ OpenID Connect and OAuth2 Provider in the world. Become an OpenID Connect and OAuth2 Provider over night. Written in Go, cloud native, headless, API-first. Available as a service on Ory Network and for self-hosters. Relied upon by OpenAI and others for web-scale security.
+  tags:
+  - go
+  - service
+  annotations:
+    github.com/project-slug: aplazo/golang.aplazo-oauth2
+    aplazo.dev/tier: '1'
+    aws.amazon.com/amazon-ecs-service-arn: arn:aws:ecs:us-west-1:159200192518:service/cl-aplazoprod/svc-account-prod-df09bfb
+    aplazo.dev/ecs-scaling-method: horizontal
+spec:
+  type: service
+  lifecycle: production
+  owner: group:default/flagship-squad
+  dependsOn:
+  - resource:default/shared-nosql-database
+  - resource:default/datadog


### PR DESCRIPTION
## Goal
Adds the root `catalog-info.yaml` required by [ID-295](https://aplazo.atlassian.net/browse/ID-295) for `golang.aplazo-oauth2`. The component is registered as `oauth2`, owned by `group:default/flagship-squad`, with operational tier `1`.

## Change type
- [ ] `feat` (new functionality)
- [ ] `fix` (bug fix)
- [ ] `refactor` (no functional change)
- [ ] `perf` (performance improvement)
- [ ] `test` (tests)
- [x] `docs` / `build/ci/chore` (catalog metadata)

## Ticket / Context
- Ticket: [ID-295](https://aplazo.atlassian.net/browse/ID-295)

## Scope
- Root `catalog-info.yaml` only; full TechDocs creation is out of scope.

## What changed
- Registered Component `oauth2` with owner `group:default/flagship-squad` and tier `1`.
- Added only verified operational annotations and authoritative catalog references.

## Validation
- [x] Backstage entity schema validation
- [x] Platform catalog reference validation

```text
`catalog-info.yaml` parsed successfully, passed Backstage entity-schema validation, and all owner/system/resource references were checked against [yaml.aplazo-platform-catalog](https://github.com/aplazo/yaml.aplazo-platform-catalog).
```

## Risk and rollback plan
- Risk level: Low
- Rollback plan: Revert this commit to remove the catalog registration.

## Quality checklist
- [x] This PR is focused on a single objective and contains one file.
- [x] It does not include secrets, credentials, sensitive files, or machine-local paths.

## Notes for reviewers
### Reviewer action required

1. Verify **all** catalog content, especially component identity, description, owner, system,
   dependencies, API exposure, operational annotations, and `aplazo.dev/tier`.
2. Push corrective commits directly to this PR branch for anything that needs adjustment.
3. Merge this PR yourself once the metadata is accurate.

If this PR is not merged by **Friday, August 7, 2026**, it will be merged for you,
bypassing branch protections if required.


[ID-295]: https://aplazo.atlassian.net/browse/ID-295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ID-295]: https://aplazo.atlassian.net/browse/ID-295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only catalog metadata with no changes to auth, deployment, or application behavior; rollback is a single-file revert.
> 
> **Overview**
> Registers the **oauth2** component in Backstage via a new root **`catalog-info.yaml`**, satisfying **ID-295** for `golang.aplazo-oauth2`.
> 
> The entity is typed as a **production** Go **service** owned by **`group:default/flagship-squad`**, linked to **`system:default/authn-authz-system`**, with **`aplazo.dev/tier: '1'`** and ECS/Datadog-oriented annotations. **`dependsOn`** lists **`shared-nosql-database`** and **`datadog`**. No application or runtime code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c36f96ae5e7c0c3aae6d367e9ba29a8e73d19d78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->