### PR TITLE
fix: ID-295 align Backstage name with DD_SERVICE

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,7 +1,7 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: oauth2
+  name: account
   title: OAUTH2
   description: The only web-scale, fully customizable OpenID Certified™ OpenID Connect and OAuth2 Provider in the world. Become an OpenID Connect and OAuth2 Provider over night. Written in Go, cloud native, headless, API-first. Available as a service on Ory Network and for self-hosters. Relied upon by OpenAI and others for web-scale security.
   tags:


### PR DESCRIPTION
Corrects the Backstage identity from `oauth2` to `account` so it matches the production Datadog service configured by Pulumi.

## Related issue(s)

- Jira: [https://aplazo.atlassian.net/browse/ID-295](https://aplazo.atlassian.net/browse/ID-295)
- Follow-up to https://github.com/aplazo/golang.aplazo-oauth2/pull/25
- Pulumi source: `node.pulumi-infrastructure/services/golang.aplazo-oauth2/Pulumi.golang.aplazo-oauth2.prod.yaml`

## Validation

- Parsed every YAML document successfully with PyYAML.
- Asserted the Component and linked API identities after the rewrite.
- Ran `git diff --check`.

## Checklist

- [x] This change is limited to `catalog-info.yaml`.
- [x] This pull request does not address a security vulnerability.
- [x] No runtime code or behavior changes.

## Further Comments

Verify `account` against the production `DD_SERVICE`/`shortname` configuration in Pulumi. If anything is inaccurate, commit the correction to this branch, then merge the PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only Backstage catalog change with no application or infrastructure runtime impact.
> 
> **Overview**
> Renames the Backstage **Component** `metadata.name` from `oauth2` to **`account`** so service catalog identity matches production **Datadog** / Pulumi (`DD_SERVICE`, ECS `svc-account-prod-*`). No code, APIs, or runtime behavior change—only `catalog-info.yaml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32220e466e597ef54ec3a75142bf01b90058bb03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->